### PR TITLE
Remove superfluous "der"

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -11,7 +11,7 @@ lang: de
 {% include component/carousel.html %}
 <div class="card-body" markdown="1">
 <h2 class="card-title">{% include element/icon.html icon="info" %} Intro</h2>
-Wir sind eine aktive Feuerwehr aus der Gemeinde Bergkirchen in Oberbayern, die überwiegend aus einem jungen Team besteht. Neben der regelmäßigen Übungen und Dienstbesprechungen, treffen wir uns zu Grillfesten und Ausflügen.
+Wir sind eine aktive Feuerwehr aus der Gemeinde Bergkirchen in Oberbayern, die überwiegend aus einem jungen Team besteht. Neben regelmäßigen Übungen und Dienstbesprechungen, treffen wir uns zu Grillfesten und Ausflügen.
 {:.card-text}
 
 Diese Webseite wird ständig weiterentwickelt und überarbeitet; also schau gerne öfter rein. Bei konkreten Fragen scheue Dich nicht uns zu [kontaktieren](/kontakt/).


### PR DESCRIPTION
Apparently, the author of the index page could not decide between the singular and plural and left one too many "der" at the end. With this PR it would have been removed. :)